### PR TITLE
fix(eslint): strip `cache` flag

### DIFF
--- a/app/templates/package-scripts.js
+++ b/app/templates/package-scripts.js
@@ -28,7 +28,7 @@ module.exports = {
     },
     eslint: {
       description: 'Check for linting errors using eslint',
-      script: 'eslint . --cache',
+      script: 'eslint .',
     },
     flow: {
       default: {

--- a/app/templates/readme.md
+++ b/app/templates/readme.md
@@ -1,14 +1,12 @@
-<div align="center">
+<p align="center">
   <img src="https://cdn.shopify.com/s/files/1/0185/5092/products/nature-0006_large.png" width="200" alt="generator-bunny" />
-  <br />
-  <br />
-</div>
+</p>
 
-<div align="center">
-  <h4>
-  Jumpstart <a href="https://nodejs.org/api/modules.html#modules_modules">node module</a>, like a bunny!
-  </h4>
-</div>
+<p align="center">
+  <strong>
+    Jumpstart <a href="https://nodejs.org/api/modules.html#modules_modules">node module</a>, like a bunny!
+  </strong>
+</p>
 
 <p align="center">
   Scaffold <a href="https://www.npmjs.com/">node module</a> or <a href="https://en.wikipedia.org/wiki/Open-source_software">open-source</a> project without having to deal with complicated setup.

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -20,7 +20,7 @@ module.exports = {
     },
     lint: {
       description: 'lint the entire project with eslint',
-      script: 'eslint . --cache',
+      script: 'eslint .',
     },
     test: {
       default: {


### PR DESCRIPTION
To make sure we can easily upgrade then lint
with the latest eslint rules that we set