### PR TITLE
replace `greenkeeper` with `renovate`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,12 @@ node_js:
 before_install:
   - yarn global add semantic-release
   - yarn global add codecov
-  - yarn global add greenkeeper-lockfile@1
-before_script:
-  - greenkeeper-lockfile-update
 script:
   - yarn start validate
 after_script:
   - codecov
-  - greenkeeper-lockfile-upload
 after_success:
   - semantic-release pre && npm publish && semantic-release post
 branches:
   only:
     - master
-    - /^greenkeeper/.*$/

--- a/app/templates/_travis.yml
+++ b/app/templates/_travis.yml
@@ -10,20 +10,14 @@ node_js:
   - '7'
   - '6'
 before_install:<% if (hasYarn) { %>
-  - yarn global add codecov
-  - yarn global add greenkeeper-lockfile@1<% } else { %>
-  - npm i -g codecov
-  - npm i -g greenkeeper-lockfile@1<% } %>
-before_script:
-  - greenkeeper-lockfile-update
+  - yarn global add codecov<% } else { %>
+  - npm i -g codecov<% } %>
 script:
   - <% if (hasYarn) { %>yarn<% } else { %>npm<% } %> start validate
 after_script:
   - codecov
-  - greenkeeper-lockfile-upload
 after_success:
   - <% if (hasYarn) { %>yarn<% } else { %>npm<% } %> start release
 branches:
   only:
     - master
-    - /^greenkeeper/.*$/

--- a/readme.md
+++ b/readme.md
@@ -28,9 +28,6 @@
   <a href="https://david-dm.org/luftywiranda13/generator-bunny">
     <img src="https://david-dm.org/luftywiranda13/generator-bunny.svg" />
   </a>
-  <a href="https://greenkeeper.io/">
-    <img src="https://badges.greenkeeper.io/luftywiranda13/generator-bunny.svg" />
-  </a>
   <br />
   <a href="https://github.com/prettier/prettier">
     <img src="https://img.shields.io/badge/styled_with-prettier-ff69b4.svg" />

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,32 @@
+{
+  "enabled": true,
+  "timezone": "Asia/Jakarta",
+  "schedule": [
+    "every 5 mins"
+  ],
+  "packageFiles": [],
+  "depTypes": [
+    {"depType": "dependencies", "semanticPrefix": "fix(deps): "},
+    "devDependencies",
+    "optionalDependencies"
+  ],
+  "ignoreDeps": [],
+  "pinVersions": true,
+  "separateMajorReleases": true,
+  "semanticCommits": true,
+  "semanticPrefix": "chore(deps): ",
+  "recreateClosed": true,
+  "rebaseStalePrs": true,
+  "prCreation": "immediate",
+  "automerge": "none",
+  "branchName": "renovate/{{depName}}-v{{newVersionMajor}}.x",
+  "commitMessage": "{{semanticPrefix}}update {{depName}} to v{{newVersion}}",
+  "prTitle": "{{semanticPrefix}}{{#if isPin}}pin{{else}}update{{/if}} {{depName}} to v{{#if isRange}}{{newVersion}}{{else}}{{#if isMajor}}{{newVersionMajor}}.x{{else}}{{newVersion}}{{/if}}{{/if}}",
+  "labels": [],
+  "assignees": [],
+  "reviewers": [],
+  "lockFileMaintenance": {
+    "commitMessage": "{{semanticPrefix}}update lockfile",
+    "prTitle": "{{semanticPrefix}}lock file maintenance"
+  }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the code_of_conduct.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the contributing.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
[`renovate`](https://github.com/singapore/renovate) is another dependencies manager like `greenkeeper`

**Why**:
<!-- Why are these changes necessary? -->
- `greenkeeper` is buggy, not really maintained, and also less configurable.
- in other hands, `renovate` provides many options to be configured and also support self-hosted/private repo

**How**:
<!-- How were these changes implemented? -->


<!-- feel free to add additional comments -->
