### PR TITLE
refactor: drop support for `yarn`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-# The use of `npm` instead of `yarn` here is intentional
-# to make sure the package also works on `npm`
-# because `npm` has a lot more users than `yarn`
 language: node_js
 notifications:
   email: false

--- a/app/index.js
+++ b/app/index.js
@@ -1,7 +1,6 @@
 const camelCase = require('lodash.camelcase');
 const chalk = require('chalk');
 const Generator = require('yeoman-generator');
-const hasbin = require('hasbin');
 const kebabCase = require('lodash.kebabcase');
 const shell = require('shelljs');
 
@@ -61,7 +60,6 @@ module.exports = class extends Generator {
         email: props.email,
         githubUsername: props.githubUsername,
         website: props.website,
-        hasYarn: hasbin.sync('yarn'),
       };
 
       this.spawnCommand('git', ['init', '--quiet']);
@@ -109,10 +107,9 @@ module.exports = class extends Generator {
     this.log();
 
     this.installDependencies({
-      skipMessage: true,
       bower: false,
-      yarn: this.tpl.hasYarn,
-      npm: !this.tpl.hasYarn,
+      npm: true,
+      skipMessage: true,
     });
   }
   end() {

--- a/app/templates/_travis.yml
+++ b/app/templates/_travis.yml
@@ -1,6 +1,3 @@
-# The use of `npm` instead of `yarn` here is intentional
-# to make sure the package also works on `npm`
-# because `npm` has a lot more users than `yarn`
 language: node_js
 notifications:
   email: false

--- a/app/templates/contributing.md
+++ b/app/templates/contributing.md
@@ -7,6 +7,8 @@ Thanks for being willing to contribute!
 
 ## Project setup
 
+> If you are using `yarn`, we suggest that you run `yarn install --no-lockfile` instead of the bare `yarn` or `yarn install`. We internally only use `npm` and decide not to generate or commit the lockfile in this repo. Read more on [What do you think of lockfiles?](https://github.com/sindresorhus/ama/issues/479#issuecomment-310661514)
+
 1.  Fork and clone the repo
 2.  `npm install` to install dependencies
 3.  `npm start validate` to validate you‘ve got it working

--- a/contributing.md
+++ b/contributing.md
@@ -7,6 +7,8 @@ Thanks for being willing to contribute!
 
 ## Project setup
 
+> If you are using `yarn`, we suggest that you run `yarn install --no-lockfile` instead of the bare `yarn` or `yarn install`. We internally only use `npm` and decide not to generate or commit the lockfile in this repo. Read more on [What do you think of lockfiles?](https://github.com/sindresorhus/ama/issues/479#issuecomment-310661514)
+
 1.  Fork and clone the repo
 2.  `npm install` to install dependencies
 3.  `npm start validate` to validate you‘ve got it working

--- a/other/roadmap.md
+++ b/other/roadmap.md
@@ -7,8 +7,6 @@ Care to help? See [`contributing.md`](../contributing.md)
 ## Want to do
 - [x] Make yeoman generator
 - [x] Create test
-- [x] Auto-detect & use yarn for dependencies installation. Fallback to npm
-- [x] Update notifier
 - [ ] Simplify installation without having to manually make new directory
 
 ## Might do

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   },
   "dependencies": {
     "chalk": "2.0.1",
-    "hasbin": "1.2.3",
     "lodash.camelcase": "4.3.0",
     "lodash.kebabcase": "4.1.1",
     "shelljs": "0.7.8",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Drop support for `yarn`. So `generator-bunny` will always use `npm` to install dependencies.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- `yarn` is buggy
- `npm` has a lot more users
- `npm` v5 is already fast enough

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you‘re unsure about any of these, don‘t hesitate to ask. We‘re here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [`contributing.md`](https://github.com/luftywiranda13/generator-bunny/blob/master/contributing.md).
