### PR TITLE
fix(contributors): wrong template placeholder

### DIFF
--- a/app/templates/readme.md
+++ b/app/templates/readme.md
@@ -42,7 +42,7 @@ import <%= camelModule %> from '<%= moduleName %>';
 Thanks goes to these people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars2.githubusercontent.com/u/22868432?v=3" width="100px;"/><br /><sub><%= name %></sub>](<%= website %>)<br />[💻](https://github.com/<%= githubUsername %>/<%= moduleName %>/commits?author=<%= githubUsername %> "Code") [📖](https://github.com/<%= githubUsername %>/<%= moduleName %>/commits?author=<%= githubUsername %> "Documentation") [🚇](#infra-<%= githubUsername %> "Infrastructure (Hosting, Build-Tools, etc") |
+| [<img src="https://avatars2.githubusercontent.com/u/22868432?v=3" width="100px;"/><br /><sub><%= name %></sub>](https://github.com/<%= githubUsername %>)<br />[💻](https://github.com/<%= githubUsername %>/<%= moduleName %>/commits?author=<%= githubUsername %> "Code") [📖](https://github.com/<%= githubUsername %>/<%= moduleName %>/commits?author=<%= githubUsername %> "Documentation") [🚇](#infra-luftywiranda13 "Infrastructure (Hosting, Build-Tools, etc)") |
 | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## PR Type
<!--- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other… Please describe:

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- update contributors placeholder in `readme.md`
- previously it used `website` as the profile link where it should be the GitHub profile link

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, -->
<!-- please also describe the impact and migration path for existing applications -->
- [ ] Yes
- [x] No

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you‘re unsure about any of these, don‘t hesitate to ask. We‘re here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [`contributing.md`](https://github.com/luftywiranda13/generator-bunny/blob/master/contributing.md).
